### PR TITLE
Dev 48974 upgrade argus from golang 1.9 to

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.9 as build
+FROM golang:1.11 as build
 WORKDIR $GOPATH/src/github.com/logicmonitor/k8s-argus
 ARG VERSION
 COPY ./ ./
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /argus -ldflags "-X \"github.com/logicmonitor/k8s-argus/pkg/constants.Version=${VERSION}\""
 
-FROM golang:1.9 as test
+FROM golang:1.11 as test
 WORKDIR $GOPATH/src/github.com/logicmonitor/k8s-argus
 RUN go get -u github.com/alecthomas/gometalinter
 RUN gometalinter --install

--- a/pkg/watch/node/node_test.go
+++ b/pkg/watch/node/node_test.go
@@ -1,8 +1,9 @@
 package node
 
 import (
-	"k8s.io/api/core/v1"
 	"testing"
+
+	"k8s.io/api/core/v1"
 )
 
 func TestGetInternalAddress(t *testing.T) {


### PR DESCRIPTION
DEV-48974 Upgrade the go version of the argus from 1.9 to 1.11